### PR TITLE
Break out inner functions; clean up test output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-Module that performs analysis of a single line input for Pelias
+Module that performs analysis of a single line of input describing a location, breaking into its constituent parts (street, city, state, country, etc).
 
 ## Installation
 

--- a/test/addressItParser.js
+++ b/test/addressItParser.js
@@ -95,8 +95,6 @@ tape('tests', function(test) {
     var query_string = '339 W Main St, Cheshire, 06410';
     var address = parser.parse(query_string);
 
-    console.log(address);
-
     t.equal(typeof address, 'object', 'valid object for the address');
     t.equal(address.street, 'W Main St', 'parsed street');
     t.deepEqual(address.regions, ['Cheshire'], 'parsed city');

--- a/test/test.js
+++ b/test/test.js
@@ -1,2 +1,12 @@
+var warnLogger = {
+  logger: {
+    level: 'warn'
+  }
+};
+
+require( 'pelias-config' )
+  .generate()
+  .deepMerge(warnLogger);
+
 require ('./libpostalParser.js');
 require ('./addressItParser.js');


### PR DESCRIPTION
Hi y'all. o/  A few things in this PR:

1. As per https://github.com/pelias/text-analyzer/issues/3, the inner functions of `parse` can safely be broken out of function scope, making them easier to reuse and grok their dependencies.

2. Tweaked the `Overvew` section a wee bit to help new users more quickly grok what this module does. (Total nitpick, but I wonder if `address-parser` would more adequately capture the spirit of the module? 'text-analyzer' made me think this was a more general text parsing module.)

3. `npm test` was writing to both the pelias logger and stdout, adding visual noise to test output. I raised the log level to 'warn' and removed a lingering `console.log`.

Overall +100 on making this nice little module so well contained. Very easy to make PRs against. :)

Fixes #3 