### PR TITLE
Add island to field mapping

### DIFF
--- a/src/libpostalParser.js
+++ b/src/libpostalParser.js
@@ -2,6 +2,7 @@ var logger = require('pelias-logger').get('text-analyzer');
 
 // mapping object from libpostal fields to pelias fields
 var field_mapping = {
+  island:         'island',
   category:       'category',
   house:          'query',
   house_number:   'number',

--- a/test/libpostalParser.js
+++ b/test/libpostalParser.js
@@ -56,6 +56,10 @@ tape('tests', function(test) {
 
       return [
         {
+          component: 'island',
+          value: 'island value'
+        },
+        {
           component: 'category',
           value: 'category value'
         },
@@ -107,6 +111,7 @@ tape('tests', function(test) {
     var actual = parser.parse('query value');
 
     var expected = {
+      island: 'island value',
       category: 'category value',
       query: 'house value',
       number: 'house_number value',


### PR DESCRIPTION
Some libpostal queries come back as islands, such as those in https://github.com/pelias/whosonfirst/issues/94. This change allows those queries to be handled in the API (no logic for handling specific cases really lives in this repo).