### PR TITLE
added `deburr` call to flatten diacriticals

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,10 +1,22 @@
 {
   "node": true,
-
   "curly": true,
-  "latedef": true,
-  "quotmark": true,
+  "eqeqeq": true,
+  "esversion": 6,
+  "freeze": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": false,
+  "newcap": true,
+  "noarg": true,
+  "noempty": true,
+  "nonbsp": true,
+  "nonew": true,
+  "plusplus": false,
+  "quotmark": "single",
   "undef": true,
-  "unused": true,
-  "trailing": true
+  "unused": false,
+  "maxparams": 4,
+  "maxdepth": 4,
+  "maxlen": 140
 }

--- a/src/libpostalParser.js
+++ b/src/libpostalParser.js
@@ -1,4 +1,5 @@
 var logger = require('pelias-logger').get('text-analyzer');
+var _ = require('lodash');
 
 // mapping object from libpostal fields to pelias fields
 var field_mapping = {
@@ -68,7 +69,7 @@ module.exports.create = function create(parse_address) {
   return {
     parse: function parse(query) {
       // call the parsing function (libpostal)
-      var parsed = parse_address(query);
+      var parsed = parse_address(_.deburr(query));
 
       logger.debug('libpostal raw: ' + JSON.stringify(parsed, null, 2));
 

--- a/test/libpostalParser.js
+++ b/test/libpostalParser.js
@@ -130,6 +130,36 @@ tape('tests', function(test) {
 
   });
 
+  test.test('all known values should be adapted to pelias model', function(t) {
+    var node_postal_mock = function(query) {
+      t.equal(query, 'query value');
+
+      return [
+        {
+          component: 'city',
+          value: 'city value'
+        },
+        {
+          component: 'state',
+          value: 'state value'
+        }
+      ];
+    };
+
+    var parser = libpostalParser.create(node_postal_mock);
+
+    var actual = parser.parse('quéry vàlue');
+
+    var expected = {
+      city: 'city value',
+      state: 'state value'
+    };
+
+    t.deepEqual(actual, expected);
+    t.end();
+
+  });
+
   test.test('unknown component names should not cause any adverse issues', function(t) {
     var node_postal_mock = function(query) {
       t.equal(query, 'query value');

--- a/test/libpostalParser.js
+++ b/test/libpostalParser.js
@@ -130,33 +130,14 @@ tape('tests', function(test) {
 
   });
 
-  test.test('all known values should be adapted to pelias model', function(t) {
-    var node_postal_mock = function(query) {
+  test.test('query with diacriticals should be deburred', function(t) {
+    var parser = libpostalParser.create((query) => {
       t.equal(query, 'query value');
+      t.end();
+      return [];
+    });
 
-      return [
-        {
-          component: 'city',
-          value: 'city value'
-        },
-        {
-          component: 'state',
-          value: 'state value'
-        }
-      ];
-    };
-
-    var parser = libpostalParser.create(node_postal_mock);
-
-    var actual = parser.parse('quéry vàlue');
-
-    var expected = {
-      city: 'city value',
-      state: 'state value'
-    };
-
-    t.deepEqual(actual, expected);
-    t.end();
+    var actual = parser.parse('q́ŭér̂ÿ v̆àl̂ū́ë');
 
   });
 


### PR DESCRIPTION
this can be removed once libpostal stops expanding diacriticals (eg - convert `ä`->`a` instead of allowing libpostal to convert it to `ae`)