### PR TITLE
return undefined if any field in the libpostal response is duplicated

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,12 @@
   "devDependencies": {
     "jshint": "^2.8.0",
     "npm-check": "git://github.com/orangejulius/npm-check.git#disable-update-check",
+    "pelias-mock-logger": "^1.1.1",
     "precommit-hook": "^3.0.0",
     "proxyquire": "^1.7.10",
+    "semantic-release": "^6.3.2",
     "tap-dot": "^1.0.1",
-    "tape": "^4.2.2",
-    "semantic-release": "^6.3.2"
+    "tape": "^4.2.2"
   },
   "pre-commit": [
     "lint",

--- a/src/libpostalParser.js
+++ b/src/libpostalParser.js
@@ -77,6 +77,7 @@ module.exports.create = function create(parse_address) {
       //  and return undefined
       // _.countBy creates a histogram from parsed, eg: { "road": 2, "city": 1 }
       if (_.some(_.countBy(parsed, o => o.component), count => count > 1)) {
+        logger.warn(`discarding libpostal parse of '${query}' due to duplicate field assignments`);
         return undefined;
       }
 

--- a/src/libpostalParser.js
+++ b/src/libpostalParser.js
@@ -66,8 +66,6 @@ module.exports.create = function create(parse_address) {
     throw new Error('parse_address parameter must be of type function');
   }
 
-  // return undefined if something is wrong with the libpostal response (2 roads, etc)
-
   return {
     parse: function parse(query) {
       // call the parsing function (libpostal)

--- a/test/libpostalParser.js
+++ b/test/libpostalParser.js
@@ -21,35 +21,6 @@ tape('tests', function(test) {
 
   });
 
-  test.test('multiple values for component should use last value found', function(t) {
-    var node_postal_mock = function(query) {
-      t.equal(query, 'query value');
-
-      return [
-        {
-          component: 'category',
-          value: 'value 1'
-        },
-        {
-          component: 'category',
-          value: 'value 2'
-        }
-      ];
-    };
-
-    var parser = libpostalParser.create(node_postal_mock);
-
-    var actual = parser.parse('query value');
-
-    var expected = {
-      category: 'value 2'
-    };
-
-    t.deepEqual(actual, expected);
-    t.end();
-
-  });
-
   test.test('all known values should be adapted to pelias model', function(t) {
     var node_postal_mock = function(query) {
       t.equal(query, 'query value');
@@ -167,6 +138,34 @@ tape('tests', function(test) {
 
     t.deepEqual(actual, expected);
     t.end();
+
+  });
+
+  test.test('libpostal returning 2 or more of a component should return undefined', t => {
+    t.plan(2);
+
+    const parser = libpostalParser.create(query => {
+      t.equal(query, 'query value');
+
+      return [
+        {
+          component: 'road',
+          value: 'road value 1'
+        },
+        {
+          component: 'city',
+          value: 'city value'
+        },
+        {
+          component: 'road',
+          value: 'road value 2'
+        }
+      ];
+    });
+
+    const actual = parser.parse('query value');
+
+    t.equals(actual, undefined, 'libpostal response should be considerd invalid');
 
   });
 


### PR DESCRIPTION
libpostal can return a duplicate field:

```
> Prolongación Ave. Alfonso Reyes #150 Col. Valle del Poniente Santa Catarina 66196

Result:

{
  "road": "prolongación ave. alfonso reyes",
  "house_number": "#150",
  "road": "col. valle del poniente santa catarina",
  "postcode": "66196"
}
```

This PR modifies the libpostal interface to consider the response invalid if any field is duplicated.  